### PR TITLE
Add NuGet publish pipeline

### DIFF
--- a/publish-nuget/README.md
+++ b/publish-nuget/README.md
@@ -1,0 +1,83 @@
+# publish-nuget
+
+A GitHub Action which pushes a package to NuGet.org, and also performs [GitHub artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) on the result.
+
+If there's already a package in NuGet with that ID and version number, the job will detect this and do no further work: it will pass successfully without attempting an artifact attestation.
+It will *not* verify that the remote artifact is identical to the one that the pipeline built, because NuGet [still does not support reproducible packs](https://github.com/NuGet/Home/issues/6229).
+
+After this action has run successfully, you should be able to NuGet install the package at the published version, and verify the attestation corresponding to the `.nupkg` file in your NuGet cache.
+
+Preconditions:
+* You're running in an image which contains a POSIX shell.
+* `dotnet` is on the path, or else has been provided through the `dotnet:` input.
+* The GitHub token in scope has `attestations: write`, `id-token: write`, and `contents: read`.
+
+An example invocation is as follows.
+Notice the recommended pattern of running in an environment (here, `main-deploy`) which is the *only* environment with access to the `NUGET_API_KEY` secret,
+and the corresponding `if` clause preventing this step from running except on the main branch of the source repository.
+
+```yaml
+publish-nuget:
+  runs-on: ubuntu-latest
+  if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}
+  needs: [all-required-checks-complete]
+  environment: main-deploy
+  permissions:
+    id-token: write
+    attestations: write
+    contents: read
+  steps:
+    - uses: actions/checkout@v4
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v4
+    # An earlier build step has produced this and run the tests.
+    - name: Download NuGet artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: nuget-package-plugin
+        path: packed
+    - name: Publish NuGet package
+      uses: G-Research/common-actions/publish-nuget@main
+      with:
+        package-name: ApiSurface
+        nuget-key: ${{ secrets.NUGET_API_KEY }}
+        nupkg-dir: packed/
+```
+
+# Inputs
+
+## `package-name`
+
+String name of the NuGet package, e.g. the string "ApiSurface" corresponding to `https://www.nuget.org/packages/ApiSurface`.
+
+## `nuget-key`
+
+A NuGet API key which has permission to push new versions of the package with the given `package-name`.
+
+## `nupkg-dir`
+
+The directory on disk within which, at the top level, contains the `${package-name}.{some-version-number}.nupkg` file to upload.
+Make sure there's only one nupkg file with any given package name in here: don't have multiple versions of the same package, because our behaviour is not defined in that case.
+
+## `dotnet` (optional)
+
+The path to the `dotnet` executable.
+(At least one consumer of this action uses Nix flakes to lock the build environment, and it doesn't seem to be trivial to launch an action within a devshell; this piece of flexibility allows such consumers to continue using this action.)
+
+# Troubleshooting
+
+## "Unable to get `ACTIONS_ID_TOKEN_REQUEST_URL` env variable"
+
+You've run the action with a GitHub cred with insufficient perms.
+
+```
+my-job-name:
+  permissions:
+    id-token: write
+    pages: attestations: write
+    contents: read
+  steps:
+    # ...
+```
+
+(Note that it's good practice to run as little code as possible within this elevated-privilege scope; hence, for example, the pattern in the main example where we download the `.nupkg` from an earlier stage rather than building it in the presence of the elevated `GITHUB_TOKEN`.)

--- a/publish-nuget/action.yaml
+++ b/publish-nuget/action.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-action.json
+name: 'publish-nuget'
+description: 'Publishes a NuGet package and attests to its contents with GitHub artifact attestation.'
+
+inputs:
+  package-name:
+    description: 'Name of the NuGet package, e.g. Newtonsoft.Json .'
+    required: true
+  nuget-key:
+    description: 'API key with which to authenticate to NuGet.org .'
+    required: true
+  nupkg-dir:
+    description: |
+      Directory in which to find the NuGet .nupkg file. We will search one level deep inside this directory for nupkg files named {package-name}.{any-string}.nupkg.
+      Note that this action is not designed to work if you have two .nupkg files inside this directory, one called Foo.0.0.0.nupkg and one called Foo.Bar.0.0.0.nupkg;
+      you should make sure there's only one package in this directory.
+    required: true
+  dotnet:
+    description: 'Path to the `dotnet` executable, if you want to override the default (e.g. because you wish to operate inside a Nix devshell).'
+    required: false
+    default: 'dotnet'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Publish to NuGet
+      shell: bash
+      id: publish-success
+      env:
+        NUGET_API_KEY: ${{ inputs.nuget-key }}
+        PACKAGE_DIR: ${{ inputs.nupkg-dir }}
+        PACKAGE_NAME: ${{ inputs.package-name }}
+        DOTNET_EXE: ${{ inputs.dotnet }}
+      run: '$GITHUB_ACTION_PATH/nuget_push.sh "$PACKAGE_DIR"/"$PACKAGE_NAME".*.nupkg'
+    - name: Wait for availability
+      shell: bash
+      id: await-package
+      if: steps.publish-success.outputs.result == 'published'
+      env:
+        PACKAGE_VERSION: ${{ steps.publish-success.outputs.version }}
+        PACKAGE_NAME: ${{ inputs.package-name }}
+      run: '$GITHUB_ACTION_PATH/await_nuget.sh'
+    # NuGet.org inserts a signature file into uploaded packages.
+    # So we have to *re-attest* it after it's uploaded.
+    # TODO: once NuGet supports reproducible packs (https://github.com/NuGet/Home/issues/6229), also attest to the exact package the pipeline built.)
+    - name: Assert package contents
+      shell: bash
+      if: steps.publish-success.outputs.result == 'published'
+      run: '$GITHUB_ACTION_PATH/assert_contents.sh'
+      env:
+        DOWNLOADED_NUPKG: ${{ steps.await-package.outputs.downloaded_nupkg }}
+        ORIGINAL_NUPKG_DIR: ${{ inputs.nupkg-dir }}
+        PACKAGE_NAME: ${{ inputs.package-name }}
+    - name: Attest Build Provenance
+      if: steps.publish-success.outputs.result == 'published'
+      uses: actions/attest-build-provenance@310b0a4a3b0b78ef57ecda988ee04b132db73ef8 # v1.4.1
+      with:
+        subject-path: ${{ steps.await-package.outputs.downloaded_nupkg }}

--- a/publish-nuget/assert_contents.sh
+++ b/publish-nuget/assert_contents.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+echo "Unzipping version from NuGet:"
+
+from_nuget="$(mktemp --directory)"
+from_local="$(mktemp --directory)"
+
+ls "${DOWNLOADED_NUPKG:?}"
+cp "$DOWNLOADED_NUPKG" "$from_nuget"/zip.zip && cd "$from_nuget" && unzip zip.zip && rm zip.zip && cd - || exit 1
+
+echo "Unzipped. Unzipping version from local build:"
+ls "${ORIGINAL_NUPKG_DIR:?}/"
+cp "$ORIGINAL_NUPKG_DIR"/"$PACKAGE_NAME".*.nupkg "$from_local"/zip.zip && cd "$from_local" && unzip zip.zip && rm zip.zip && cd - || exit 1
+
+echo "Unzipped."
+
+from_nuget_out="$(mktemp --tmpdir tmp.XXXXXXXX.txt)"
+from_local_out="$(mktemp --tmpdir tmp.XXXXXXXX.txt)"
+
+echo "Collecting file contents. Contents from NuGet source file: $from_nuget_out. Contents from locally built source file: $from_local_out."
+
+cd "$from_local" && find . -type f -exec sha256sum {} \; | sort | tee "$from_local_out" && cd .. || exit 1
+cd "$from_nuget" && find . -type f -and -not -name '.signature.p7s' -exec sha256sum {} \; | sort | tee "$from_nuget_out" && cd .. || exit 1
+
+echo "Diffing."
+
+diff "$from_local_out" "$from_nuget_out"

--- a/publish-nuget/await_nuget.sh
+++ b/publish-nuget/await_nuget.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "$PACKAGE_NAME"
+echo "$PACKAGE_VERSION"
+dest_dir=$(mktemp --directory)
+dest="$dest_dir/$PACKAGE_NAME.$PACKAGE_VERSION.nupkg"
+while ! curl -L --fail -o "$dest" "https://www.nuget.org/api/v2/package/$PACKAGE_NAME/$PACKAGE_VERSION" ; do
+  sleep 10;
+done
+
+echo "downloaded_nupkg=$dest" >> "$GITHUB_OUTPUT"

--- a/publish-nuget/nuget_push.sh
+++ b/publish-nuget/nuget_push.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Expects an env var NUGET_API_KEY.
+# Provides step results of "version=${version number pushed}" and "result={published|skipped}".
+# Succeeds with exit code 0 if a package already exists at the given version in NuGet, and sets `result=skipped`.
+# Fails with exit code 1 if we fail to publish for any other reason.
+
+NUGET_SOURCE="https://api.nuget.org/v3/index.json"
+cd "$PACKAGE_DIR" || exit 1
+SOURCE_NUPKG=$(find . -maxdepth 1 -type f -name '*.nupkg')
+
+# Get the last three dot-separated chunks of the nupkg file path; interpret this as a version number.
+PACKAGE_VERSION=$(basename "$SOURCE_NUPKG" | rev | cut -d '.' -f 2-4 | rev)
+
+echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+
+nuget_output=$(mktemp)
+
+if ! "$DOTNET_EXE" nuget push "$SOURCE_NUPKG" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE" > "$nuget_output" ; then
+    cat "$nuget_output"
+    if grep 'already exists and cannot be modified' "$nuget_output" ; then
+        echo "result=skipped" >> "$GITHUB_OUTPUT"
+        exit 0
+    else
+        echo "Unexpected failure to upload"
+        exit 1
+    fi
+fi
+
+cat "$nuget_output"
+
+echo "result=published" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This is essentially https://github.com/Smaug123/publish-nuget-action at revision 76df889166633c2dc613560c092882aabe260df0.

Fixes #3.

Observe the [trial run](https://github.com/Smaug123/test-repo/actions/runs/10451202694/job/28937120595) against https://github.com/Smaug123/test-repo/commit/12e3c6ab59f8e8dd3b1d9fd3b1358f3f187d0c64 demonstrating that this gracefully succeeds when the package already exists in the repo at that version (so this is safe to include in an idempotent pipeline), and the [trial run](https://github.com/Smaug123/test-repo/actions/runs/10451218842/job/28937177389) against https://github.com/Smaug123/test-repo/commit/05b98f87ab617d45e5229913fa69ca837096e978 demonstrating that we push a new version of the package when that version doesn't already exist in NuGet.org. Observe that it does indeed attest the package:

```
~ > curl -L -o WoofWare.Test.Thing.nupkg "https://www.nuget.org/api/v2/package/WoofWare.Test.Thing/0.0.15" && gh attestation verify ./WoofWare.Test.Thing.nupkg --owner Smaug123
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   186    0   186    0     0    352      0 --:--:-- --:--:-- --:--:--   352
100 18134  100 18134    0     0  25752      0 --:--:-- --:--:-- --:--:--  210k
Loaded digest sha256:68d858756b45ef332296b69a4cdff1f61cf7a75f9f6d84d1343ddf9b740212e7 for file://WoofWare.Test.Thing.nupkg
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:68d858756b45ef332296b69a4cdff1f61cf7a75f9f6d84d1343ddf9b740212e7 was attested by:
REPO                PREDICATE_TYPE                  WORKFLOW
Smaug123/test-repo  https://slsa.dev/provenance/v1  .github/workflows/dotnet.yaml@refs/heads/main
```

Once this is merged, I'll move the RQF-owned libraries over to this.