### PR TITLE
Create action for GitHub release

### DIFF
--- a/github-release/README.md
+++ b/github-release/README.md
@@ -1,0 +1,72 @@
+# github-release
+
+A GitHub Action which creates a [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).
+
+```yaml
+github-release:
+  runs-on: ubuntu-latest
+  if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}
+  needs: [all-required-checks-complete]
+  environment: main-deploy
+  permissions:
+    contents: write
+  steps:
+    - name: Compute tag
+      id: compute-tag
+      # Do something to compute the tag here, e.g. "ApiSurface_1.2.3".
+      # Optionally also push it to the repo; or alternatively just let the `github-release` step do the tag creation.
+    - name: Create GitHub release
+      uses: G-Research/common-actions/github-release@main
+      with:
+        tag: ${{ steps.compute-tag.output }}
+        target-commitish: ${{ github.sha }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Optionally:
+        generate-release-notes: true
+        draft: true
+        prerelease: true
+```
+
+# Inputs
+
+## `tag`
+
+The tag name to which the GitHub release will correspond.
+This is used both as the release name and as the tag to which the release points.
+
+If this doesn't exist at the time this step runs, the tag is created to point to `target-commitish`.
+
+## `github-token`
+
+A GitHub token with at least `contents: "write"` perms, and optionally also `actions: "write"` (though GitHub does not document the conditions under which this is required).
+This should usually be `github-token: ${{ secrets.GITHUB_TOKEN }}`, and you need to remember the appropriate `permissions` block in the job config.
+
+## `target-commitish`
+
+Specifies the commitish value that will be the target for the release's tag.
+Required if the supplied `tag` does not reference an existing tag, and also required if `generate-release-notes` is true (though GitHub does not document this).
+
+If you don't specify this, the current head of the repo's default branch is used; it seems likely that this results in race conditions when multiple instances of the pipeline run simultaneously.
+`${{ github.sha }}` seems like a sensible value to use when the workflow is running on the default branch.
+
+## `draft`
+
+Boolean.
+Set to `true` to mark this GitHub release as a draft.
+
+## `prerelease`
+
+Boolean.
+Set to `true` to mark this GitHub release as a prerelease.
+
+## `generate-release-notes`
+
+Boolean.
+Enables [generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) on the GitHub release.
+If you set this, you must also set `target-commitish` (even if the `tag` already exists), though GitHub does not appear to document this fact.
+
+# Why?
+
+GitHub releasing is an operation which is intended to happen in a privileged context.
+It's very simple to do using the GitHub API, but GitHub appear not to offer a first-party action to do it.
+We prefer to keep our dependency footprints small in privileged contexts; so we simply make the necessary API calls manually.

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -25,6 +25,7 @@ github-release:
         generate-release-notes: true
         draft: true
         prerelease: true
+        binary-contents: path/to/binary
 ```
 
 # Inputs
@@ -64,6 +65,10 @@ Set to `true` to mark this GitHub release as a prerelease.
 Boolean.
 Enables [generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) on the GitHub release.
 If you set this, you must also set `target-commitish` (even if the `tag` already exists), though GitHub does not appear to document this fact.
+
+## `binary-contents`
+
+A path to some binary data to upload to the release as a release asset.
 
 # Why?
 

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -25,7 +25,9 @@ github-release:
         generate-release-notes: true
         draft: true
         prerelease: true
-        binary-contents: path/to/binary
+        binary-contents: |
+          path/to/binary1
+          path/to/binary2
 ```
 
 # Inputs
@@ -68,7 +70,7 @@ If you set this, you must also set `target-commitish` (even if the `tag` already
 
 ## `binary-contents`
 
-A path to some binary data to upload to the release as a release asset.
+A newline-separated list of paths to some binary data to upload to the release as a release asset.
 
 # Why?
 

--- a/github-release/action.yaml
+++ b/github-release/action.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-action.json
+name: 'github-release'
+description: 'Creates a GitHub release corresponding to the given tag.'
+
+inputs:
+  tag:
+    description: |
+      The tag name to which the GitHub release will correspond. This is used as the release name.
+      If no tag exists with this name, the GitHub release will *create* this tag, pointing to `target-commitish` (which defaults to the empty string, i.e. "the current head of the default branch of the repository").
+      On the other hand, if a tag with this name exists, GitHub will simply create a release which points to the tag, and will ignore the `target-commitish` entirely.
+    required: false
+  github-token:
+    description: 'A GitHub token with at least "contents: write" perms.'
+    required: true
+  draft:
+    description: 'Whether the resulting GitHub release should be a draft release.'
+    default: 'false'
+    required: false
+  prerelease:
+    description: 'Whether the resulting GitHub release should be a prerelease.'
+    default: 'false'
+    required: false
+  generate-release-notes:
+    description: 'Whether to enable [generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) on the GitHub release. If you set this, you must set target-commitish.'
+    default: 'false'
+    required: false
+  target-commitish:
+    description: |
+      Specifies the commitish value that will be the target for the release's tag.
+      Required if the supplied `tag` input does not reference an existing tag; ignored if the referenced tag already exists.
+      You must set this if generate-release-notes is true.
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: GitHub Release
+      shell: bash
+      env:
+        GENERATE_RELEASE_NOTES: ${{ inputs.generate-release-notes }}
+        DRAFT: ${{ inputs.draft }}
+        PRERELEASE: ${{ inputs.prerelease }}
+        TAG: ${{ inputs.tag }}
+        GITHUB_TOKEN: "${{ inputs.github-token }}"
+        TARGET_COMMITISH: "${{ inputs.target-commitish }}"
+      run: '$GITHUB_ACTION_PATH/github-release.sh'

--- a/github-release/action.yaml
+++ b/github-release/action.yaml
@@ -3,6 +3,9 @@ name: 'github-release'
 description: 'Creates a GitHub release corresponding to the given tag.'
 
 inputs:
+  binary-contents:
+    description: 'A binary artefact to upload as part of the release. (Omit this to create an empty release.)'
+    required: false
   tag:
     description: |
       The tag name to which the GitHub release will correspond. This is used as the release name.
@@ -43,4 +46,5 @@ runs:
         TAG: ${{ inputs.tag }}
         GITHUB_TOKEN: "${{ inputs.github-token }}"
         TARGET_COMMITISH: "${{ inputs.target-commitish }}"
+        BINARY_CONTENTS: "${{ inputs.binary-contents }}"
       run: '$GITHUB_ACTION_PATH/github-release.sh'

--- a/github-release/action.yaml
+++ b/github-release/action.yaml
@@ -4,7 +4,7 @@ description: 'Creates a GitHub release corresponding to the given tag.'
 
 inputs:
   binary-contents:
-    description: 'A binary artefact to upload as part of the release. (Omit this to create an empty release.)'
+    description: 'Newline-separated list of paths to binary artefacts to upload as part of the release. (Omit this to create an empty release.)'
     required: false
   tag:
     description: |

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+DRAFT=${DRAFT:-false}
+PRERELEASE=${PRERELEASE:-false}
+GENERATE_RELEASE_NOTES=${GENERATE_RELEASE_NOTES:-false}
+
+# target_commitish is empty by default to indicate the repo default branch
+curl_body='{"tag_name":"'"$TAG"'","target_commitish":"'"$TARGET_COMMITISH"'","name":"'"$TAG"'","draft":'"$DRAFT"',"prerelease": '"$PRERELEASE"',"generate_release_notes":'"$GENERATE_RELEASE_NOTES"'}'
+
+echo "cURL body: $curl_body"
+
+# Some errors are expected. For example, to make our pipelines idempotent, we gracefully do nothing
+# when a release already exists with the given name.
+HANDLE_OUTPUT=''
+handle_error() {
+    ERROR_OUTPUT="$1"
+    exit_message=$(echo "$ERROR_OUTPUT" | jq -r --exit-status 'if .errors | length == 1 then .errors[0].code else null end')
+    if [ "$exit_message" = "already_exists" ] ; then
+        HANDLE_OUTPUT="Did not create GitHub release because it already exists at this version."
+    else
+        echo "Unexpected error output from curl: $(cat curl_output.json)"
+        echo "JQ output: $(exit_message)"
+        exit 2
+    fi
+}
+
+CURL_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases"
+
+echo "curl to: $CURL_URL"
+
+if [ "$DRY_RUN" != 1 ] ; then
+    if curl --fail-with-body -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "$CURL_URL" -d "$curl_body" > curl_output.json; then
+        echo "Curl succeeded."
+    else
+        handle_error "$(cat curl_output.json)"
+        echo "$HANDLE_OUTPUT"
+    fi
+fi

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -56,7 +56,7 @@ add_file_to_release() {
 }
 
 if [ -n "$BINARY_CONTENTS" ] ; then
-    printf '%s\n' "$BINARY_CONTENTS" | while IFS= read -r line; do
+    echo "$BINARY_CONTENTS" | while IFS= read -r line; do
         add_file_to_release "$line"
     done
 fi

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -51,12 +51,15 @@ add_file_to_release() {
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         -H "Content-Type: application/octet-stream" \
+        --fail \
         "$CURL_URL" \
         --data-binary "@$1"
 }
 
 if [ -n "$BINARY_CONTENTS" ] ; then
     echo "$BINARY_CONTENTS" | while IFS= read -r line; do
-        add_file_to_release "$line"
+        if [ -n "$line" ]; then
+            add_file_to_release "$line"
+        fi
     done
 fi

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -28,7 +28,7 @@ handle_error() {
 
 CURL_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases"
 
-echo "curl to: $CURL_URL"
+echo "Creating release with curl: $CURL_URL"
 
 if [ "$DRY_RUN" != 1 ] ; then
     if curl --fail-with-body -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "$CURL_URL" -d "$curl_body" > curl_output.json; then
@@ -40,12 +40,11 @@ if [ "$DRY_RUN" != 1 ] ; then
     fi
 fi
 
-# Upload the binary, if specified
-
-if [ -n "$BINARY_CONTENTS" ] ; then
-    RELEASE_NAME="$(basename "$BINARY_CONTENTS")"
+# Upload the binary, if specified.
+add_file_to_release() {
+    RELEASE_NAME="$(basename "$1")"
     CURL_URL="https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=$RELEASE_NAME"
-    echo "Posting binary contents to $CURL_URL"
+    echo "Posting binary contents of $1 to $CURL_URL"
 
     curl -X POST \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -53,5 +52,11 @@ if [ -n "$BINARY_CONTENTS" ] ; then
         -H "X-GitHub-Api-Version: 2022-11-28" \
         -H "Content-Type: application/octet-stream" \
         "$CURL_URL" \
-        --data-binary "@$BINARY_CONTENTS"
+        --data-binary "@$1"
+}
+
+if [ -n "$BINARY_CONTENTS" ] ; then
+    printf '%s\n' "$BINARY_CONTENTS" | while IFS= read -r line; do
+        add_file_to_release "$line"
+    done
 fi


### PR DESCRIPTION
Rationale is in the "Why?" section of the README.

Observe the [successful run](https://github.com/Smaug123/test-repo/actions/runs/12176186326/job/33961396316) against [a test PR](https://github.com/Smaug123/test-repo/pull/6/commits/35f11423e8de1e8ebcbd4a5dfd196da15cf53030). This produced the expected releases.

The "upload binary data" is tested: https://github.com/Smaug123/test-repo/releases/tag/tmp.xAUcJ5OU is one such release, constructed from https://github.com/Smaug123/test-repo/pull/6 at commit 35f11423e8de1e8ebcbd4a5dfd196da15cf53030 .