### PR TITLE
Create action for GitHub release (as a Docker action)

### DIFF
--- a/github-release/Dockerfile
+++ b/github-release/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine
+
+COPY entrypoint.sh /entrypoint.sh
+
+# The version of `jq` in `ubuntu-latest` is 1.6, which is too old
+# for --nul-output.
+
+# I don't know whether `ash` supports the `$'\0'` syntax, and can't easily
+# find out.
+
+RUN apk add --no-cache jq bash curl
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -1,0 +1,72 @@
+# github-release
+
+A GitHub Action which creates a [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).
+
+```yaml
+github-release:
+  runs-on: ubuntu-latest
+  if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}
+  needs: [all-required-checks-complete]
+  environment: main-deploy
+  permissions:
+    contents: write
+  steps:
+    - name: Compute tag
+      id: compute-tag
+      # Do something to compute the tag here, e.g. "ApiSurface_1.2.3".
+      # Optionally also push it to the repo; or alternatively just let the `github-release` step do the tag creation.
+    - name: Create GitHub release
+      uses: G-Research/common-actions/github-release@main
+      with:
+        tag: ${{ steps.compute-tag.output }}
+        target-commitish: ${{ github.sha }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Optionally:
+        generate-release-notes: true
+        draft: true
+        prerelease: true
+```
+
+# Inputs
+
+## `tag`
+
+The tag name to which the GitHub release will correspond.
+This is used both as the release name and as the tag to which the release points.
+
+If this doesn't exist at the time this step runs, the tag is created to point to `target-commitish`.
+
+## `github-token`
+
+A GitHub token with at least `contents: "write"` perms, and optionally also `actions: "write"` (though GitHub does not document the conditions under which this is required).
+This should usually be `github-token: ${{ secrets.GITHUB_TOKEN }}`, and you need to remember the appropriate `permissions` block in the job config.
+
+## `target-commitish`
+
+Specifies the commitish value that will be the target for the release's tag.
+Required if the supplied `tag` does not reference an existing tag, and also required if `generate-release-notes` is true (though GitHub does not document this).
+
+If you don't specify this, the current head of the repo's default branch is used; it seems likely that this results in race conditions when multiple instances of the pipeline run simultaneously.
+`${{ github.sha }}` seems like a sensible value to use when the workflow is running on the default branch.
+
+## `draft`
+
+Boolean.
+Set to `true` to mark this GitHub release as a draft.
+
+## `prerelease`
+
+Boolean.
+Set to `true` to mark this GitHub release as a prerelease.
+
+## `generate-release-notes`
+
+Boolean.
+Enables [generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) on the GitHub release.
+If you set this, you must also set `target-commitish` (even if the `tag` already exists), though GitHub does not appear to document this fact.
+
+# Why?
+
+GitHub releasing is an operation which is intended to happen in a privileged context.
+It's very simple to do using the GitHub API, but GitHub appear not to offer a first-party action to do it.
+We prefer to keep our dependency footprints small in privileged contexts; so we simply make the necessary API calls manually.

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -25,8 +25,16 @@ github-release:
         generate-release-notes: true
         draft: true
         prerelease: true
-        binary-contents: path/to/binary
+        binary-contents: |
+          path/to/binary1
+          path/to/binary2
 ```
+
+# Why?
+
+GitHub releasing is an operation which is intended to happen in a privileged context.
+It's very simple to do using the GitHub API, but GitHub appear not to offer a first-party action to do it.
+We prefer to keep our dependency footprints small in privileged contexts; so we simply make the necessary API calls manually.
 
 # Inputs
 
@@ -39,7 +47,7 @@ If this doesn't exist at the time this step runs, the tag is created to point to
 
 ## `github-token`
 
-A GitHub token with at least `contents: "write"` perms, and optionally also `actions: "write"` (though GitHub does not document the conditions under which this is required).
+A GitHub token with at least `contents: "write"` perms; also optionall `actions: "write"` (GitHub does not appear to document the conditions under which this is required; we believe it's when you want this step to run correctly on pull requests which edit a `.github/` workflow file).
 This should usually be `github-token: ${{ secrets.GITHUB_TOKEN }}`, and you need to remember the appropriate `permissions` block in the job config.
 
 ## `target-commitish`
@@ -68,10 +76,32 @@ If you set this, you must also set `target-commitish` (even if the `tag` already
 
 ## `binary-contents`
 
-A path to some binary data to upload to the release as a release asset.
+Paths to some binary data to upload to the release as release assets.
 
-# Why?
+The simpler (but less flexible) way to pass inputs here is as a single string (if you want to upload only one asset):
 
-GitHub releasing is an operation which is intended to happen in a privileged context.
-It's very simple to do using the GitHub API, but GitHub appear not to offer a first-party action to do it.
-We prefer to keep our dependency footprints small in privileged contexts; so we simply make the necessary API calls manually.
+```yaml
+with:
+  binary-contents: foo
+```
+
+or as a newline-delimited string list:
+
+```yaml
+with:
+  binary-contents: |
+    foo
+    bar
+    baz
+```
+
+However, you may instead use the canonical input format, a string containing a JSON array of filepaths.
+(You *must* use this format if any of your paths contain newlines, or if they are themselves certain kinds of valid JSON string.)
+This eccentric input method is because [GitHub Actions doesn't support lists](https://github.com/actions/toolkit/issues/184).
+
+```yaml
+with:
+  binary-contents: "[\"hello\nworld.txt\",\"foo.txt\"]"
+```
+
+(We wish you the best of luck constructing this string. YAML is hard for humans to read or write; use [an interactive renderer](https://yaml-online-parser.appspot.com/).)

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -79,6 +79,9 @@ If you set this, you must also set `target-commitish` (even if the `tag` already
 Paths to some binary data to upload to the release as release assets.
 These paths are relative to the workspace; because the action runs in a Docker container, you cannot e.g. write data to `/tmp` in an earlier step and then release it from there.
 
+Note that GitHub silently rewrites release asset filenames so that they are not a bare `.extension`.
+For example, if you tried to release the file `.gitignore`, it would be released under the name `default.gitignore`.
+
 The simpler (but less flexible) way to pass inputs here is as a single string (if you want to upload only one asset):
 
 ```yaml

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -77,6 +77,7 @@ If you set this, you must also set `target-commitish` (even if the `tag` already
 ## `binary-contents`
 
 Paths to some binary data to upload to the release as release assets.
+These paths are relative to the workspace; because the action runs in a Docker container, you cannot e.g. write data to `/tmp` in an earlier step and then release it from there.
 
 The simpler (but less flexible) way to pass inputs here is as a single string (if you want to upload only one asset):
 

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -25,6 +25,7 @@ github-release:
         generate-release-notes: true
         draft: true
         prerelease: true
+        binary-contents: path/to/binary
 ```
 
 # Inputs
@@ -64,6 +65,10 @@ Set to `true` to mark this GitHub release as a prerelease.
 Boolean.
 Enables [generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) on the GitHub release.
 If you set this, you must also set `target-commitish` (even if the `tag` already exists), though GitHub does not appear to document this fact.
+
+## `binary-contents`
+
+A path to some binary data to upload to the release as a release asset.
 
 # Why?
 

--- a/github-release/action.yaml
+++ b/github-release/action.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-action.json
+name: 'github-release'
+description: 'Creates a GitHub release corresponding to the given tag.'
+
+inputs:
+  tag:
+    description: |
+      The tag name to which the GitHub release will correspond. This is used as the release name.
+      If no tag exists with this name, the GitHub release will *create* this tag, pointing to `target-commitish` (which defaults to the empty string, i.e. "the current head of the default branch of the repository").
+      On the other hand, if a tag with this name exists, GitHub will simply create a release which points to the tag, and will ignore the `target-commitish` entirely.
+    required: false
+  github-token:
+    description: 'A GitHub token with at least "contents: write" perms.'
+    required: true
+  draft:
+    description: 'Whether the resulting GitHub release should be a draft release.'
+    default: 'false'
+    required: false
+  prerelease:
+    description: 'Whether the resulting GitHub release should be a prerelease.'
+    default: 'false'
+    required: false
+  generate-release-notes:
+    description: 'Whether to enable [generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) on the GitHub release. If you set this, you must set target-commitish.'
+    default: 'false'
+    required: false
+  target-commitish:
+    description: |
+      Specifies the commitish value that will be the target for the release's tag.
+      Required if the supplied `tag` input does not reference an existing tag; ignored if the referenced tag already exists.
+      You must set this if generate-release-notes is true.
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: GitHub Release
+      shell: bash
+      env:
+        GENERATE_RELEASE_NOTES: ${{ inputs.generate-release-notes }}
+        DRAFT: ${{ inputs.draft }}
+        PRERELEASE: ${{ inputs.prerelease }}
+        TAG: ${{ inputs.tag }}
+        GITHUB_TOKEN: "${{ inputs.github-token }}"
+        TARGET_COMMITISH: "${{ inputs.target-commitish }}"
+      run: '$GITHUB_ACTION_PATH/github-release.sh'

--- a/github-release/action.yaml
+++ b/github-release/action.yaml
@@ -3,6 +3,9 @@ name: 'github-release'
 description: 'Creates a GitHub release corresponding to the given tag.'
 
 inputs:
+  binary-contents:
+    description: 'A binary artefact to upload as part of the release. (Omit this to create an empty release.)'
+    required: false
   tag:
     description: |
       The tag name to which the GitHub release will correspond. This is used as the release name.
@@ -43,4 +46,5 @@ runs:
         TAG: ${{ inputs.tag }}
         GITHUB_TOKEN: "${{ inputs.github-token }}"
         TARGET_COMMITISH: "${{ inputs.target-commitish }}"
+        BINARY_CONTENTS: "${{ inputs.binary-contents }}"
       run: '$GITHUB_ACTION_PATH/github-release.sh'

--- a/github-release/action.yaml
+++ b/github-release/action.yaml
@@ -4,7 +4,7 @@ description: 'Creates a GitHub release corresponding to the given tag.'
 
 inputs:
   binary-contents:
-    description: 'A binary artefact to upload as part of the release. (Omit this to create an empty release.)'
+    description: 'Binary artefact(s) to upload as part of the release. (Omit this to create an empty release, or use a multi-line string to upload multiple artefacts at once; see the README for details if your paths contain newlines.)'
     required: false
   tag:
     description: |

--- a/github-release/action.yaml
+++ b/github-release/action.yaml
@@ -35,16 +35,13 @@ inputs:
     required: false
 
 runs:
-  using: "composite"
-  steps:
-    - name: GitHub Release
-      shell: bash
-      env:
-        GENERATE_RELEASE_NOTES: ${{ inputs.generate-release-notes }}
-        DRAFT: ${{ inputs.draft }}
-        PRERELEASE: ${{ inputs.prerelease }}
-        TAG: ${{ inputs.tag }}
-        GITHUB_TOKEN: "${{ inputs.github-token }}"
-        TARGET_COMMITISH: "${{ inputs.target-commitish }}"
-        BINARY_CONTENTS: "${{ inputs.binary-contents }}"
-      run: '$GITHUB_ACTION_PATH/github-release.sh'
+  using: "docker"
+  image: ./Dockerfile
+  env:
+    GENERATE_RELEASE_NOTES: ${{ inputs.generate-release-notes }}
+    DRAFT: ${{ inputs.draft }}
+    PRERELEASE: ${{ inputs.prerelease }}
+    TAG: ${{ inputs.tag }}
+    GITHUB_TOKEN: "${{ inputs.github-token }}"
+    TARGET_COMMITISH: "${{ inputs.target-commitish }}"
+    BINARY_CONTENTS: "${{ inputs.binary-contents }}"

--- a/github-release/entrypoint.sh
+++ b/github-release/entrypoint.sh
@@ -61,10 +61,12 @@ if echo "$BINARY_CONTENTS" | jq --exit-status '.[]' >/dev/null 2>&1 ; then
     echo "$BINARY_CONTENTS" | jq --raw-output0 '.[]' | while IFS= read -r -d $'\0' filepath; do
         release "$filepath"
     done
-else
+elif [ -n "$BINARY_CONTENTS" ] ; then
     # Not JSON. Treat as a newline-delimited list of filepaths.
     # If the user wants to pass a newline in one of the paths, they must use JSON.
     echo "$BINARY_CONTENTS" | while IFS= read -r filepath; do
-        release "$filepath"
+        if [ -n "$filepath" ] ; then
+          release "$filepath"
+        fi
     done
 fi

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+DRAFT=${DRAFT:-false}
+PRERELEASE=${PRERELEASE:-false}
+GENERATE_RELEASE_NOTES=${GENERATE_RELEASE_NOTES:-false}
+
+# target_commitish is empty by default to indicate the repo default branch
+curl_body='{"tag_name":"'"$TAG"'","target_commitish":"'"$TARGET_COMMITISH"'","name":"'"$TAG"'","draft":'"$DRAFT"',"prerelease": '"$PRERELEASE"',"generate_release_notes":'"$GENERATE_RELEASE_NOTES"'}'
+
+echo "cURL body: $curl_body"
+
+# Some errors are expected. For example, to make our pipelines idempotent, we gracefully do nothing
+# when a release already exists with the given name.
+HANDLE_OUTPUT=''
+handle_error() {
+    ERROR_OUTPUT="$1"
+    exit_message=$(echo "$ERROR_OUTPUT" | jq -r --exit-status 'if .errors | length == 1 then .errors[0].code else null end')
+    if [ "$exit_message" = "already_exists" ] ; then
+        HANDLE_OUTPUT="Did not create GitHub release because it already exists at this version."
+    else
+        echo "Unexpected error output from curl: $(cat curl_output.json)"
+        echo "JQ output: $(exit_message)"
+        exit 2
+    fi
+}
+
+CURL_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases"
+
+echo "curl to: $CURL_URL"
+
+if [ "$DRY_RUN" != 1 ] ; then
+    if curl --fail-with-body -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "$CURL_URL" -d "$curl_body" > curl_output.json; then
+        echo "Curl succeeded."
+    else
+        handle_error "$(cat curl_output.json)"
+        echo "$HANDLE_OUTPUT"
+    fi
+fi


### PR DESCRIPTION
This is #6, but allowing multiple files to be uploaded.

Everything about GitHub Actions doesn't *quite* work.

* I used `jq` so as not to have to invent our own escaping syntax.
* POSIX sh apparently just doesn't have a way to iterate over NUL-delimited strings, like, at all? And if you use any other character as a delimiter, you restrict the filenames that can be input. So I installed Bash.
* I used Docker because otherwise we are very unlikely to be running with `jq` at version 1.7 or greater (`ubuntu-latest` has 1.6). At version 1.6 or less, there is (as far as I can tell) no safe way to produce a NUL-delimited string output from `jq`.

I've tried to document some of the gotchas of GitHub releases that I found.

See https://github.com/Smaug123/test-repo/releases/tag/tmp.ZOxjMiYS for an example release, which was made from https://github.com/Smaug123/test-repo/pull/5 at commit af0f0c830bf09bddd0b0338ea588c5435a19272f (see https://github.com/Smaug123/test-repo/blob/af0f0c830bf09bddd0b0338ea588c5435a19272f/.github/workflows/dotnet.yaml and the run at https://github.com/Smaug123/test-repo/actions/runs/11417819741/job/31770547634 ).