### PR TITLE
Add dry-run option to github-release

### DIFF
--- a/github-release/README.md
+++ b/github-release/README.md
@@ -72,6 +72,10 @@ If you set this, you must also set `target-commitish` (even if the `tag` already
 
 A newline-separated list of paths to some binary data to upload to the release as a release asset.
 
+## `dry-run`
+
+Set this to any value which is not `"false"` to skip the actual push, instead only printing out what would be done.
+
 # Why?
 
 GitHub releasing is an operation which is intended to happen in a privileged context.

--- a/github-release/action.yaml
+++ b/github-release/action.yaml
@@ -33,6 +33,10 @@ inputs:
       Required if the supplied `tag` input does not reference an existing tag; ignored if the referenced tag already exists.
       You must set this if generate-release-notes is true.
     required: false
+  dry-run:
+    description: 'Set to a non-"false" value to skip the actual push, instead only printing out what would be done.'
+    default: 'false'
+    required: false
 
 runs:
   using: "composite"
@@ -47,4 +51,5 @@ runs:
         GITHUB_TOKEN: "${{ inputs.github-token }}"
         TARGET_COMMITISH: "${{ inputs.target-commitish }}"
         BINARY_CONTENTS: "${{ inputs.binary-contents }}"
+        DRY_RUN: "${{ inputs.dry-run }}"
       run: '$GITHUB_ACTION_PATH/github-release.sh'

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -3,6 +3,7 @@
 DRAFT=${DRAFT:-false}
 PRERELEASE=${PRERELEASE:-false}
 GENERATE_RELEASE_NOTES=${GENERATE_RELEASE_NOTES:-false}
+DRY_RUN=${DRY_RUN:-false}
 
 # target_commitish is empty by default to indicate the repo default branch
 curl_body='{"tag_name":"'"$TAG"'","target_commitish":"'"$TARGET_COMMITISH"'","name":"'"$TAG"'","draft":'"$DRAFT"',"prerelease": '"$PRERELEASE"',"generate_release_notes":'"$GENERATE_RELEASE_NOTES"'}'
@@ -30,7 +31,7 @@ CURL_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases"
 
 echo "Creating release with curl: $CURL_URL"
 
-if [ "$DRY_RUN" != 1 ] ; then
+if [ "$DRY_RUN" = "false" ] ; then
     if curl --fail-with-body -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "$CURL_URL" -d "$curl_body" > curl_output.json; then
         echo "Curl succeeded."
         RELEASE_ID="$(jq --raw-output --exit-status '.id' curl_output.json)"
@@ -46,14 +47,16 @@ add_file_to_release() {
     CURL_URL="https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=$RELEASE_NAME"
     echo "Posting binary contents of $1 to $CURL_URL"
 
-    curl -X POST \
-        -H "Authorization: Bearer $GITHUB_TOKEN" \
-        -H "Accept: application/vnd.github+json" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        -H "Content-Type: application/octet-stream" \
-        --fail \
-        "$CURL_URL" \
-        --data-binary "@$1"
+    if [ "$DRY_RUN" = "false" ] ; then
+        curl -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/octet-stream" \
+            --fail \
+            "$CURL_URL" \
+            --data-binary "@$1"
+    fi
 }
 
 if [ -n "$BINARY_CONTENTS" ] ; then


### PR DESCRIPTION
I find myself debugging on `main` trying to consume this, so let's have a proper dry-run.