### PR TITLE
Ignore release assets with the same name as existing ones

### DIFF
--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -48,14 +48,18 @@ add_file_to_release() {
     echo "Posting binary contents of $1 to $CURL_URL"
 
     if [ "$DRY_RUN" = "false" ] ; then
-        curl -X POST \
+        if ! curl -X POST \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Content-Type: application/octet-stream" \
             --fail \
             "$CURL_URL" \
-            --data-binary "@$1"
+            --data-binary "@$1" > curl_output.json; then
+            cat curl_output.json
+            echo "Failed to upload asset"
+            exit 1
+        fi
     fi
 }
 

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -60,7 +60,7 @@ add_file_to_release() {
             -o curl_output.txt)
         if [ "$http_code" -eq 422 ] ; then
             echo "Not attempting to replace asset with the same name that was already uploaded."
-        else
+        elif [ "$http_code" -ne 200 ] && [ "$http_code" -ne 201 ] ; then
             cat curl_output.txt
             echo "Failed to upload asset"
             exit 1

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -54,11 +54,19 @@ add_file_to_release() {
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Content-Type: application/octet-stream" \
             --fail \
+            --silent \
             "$CURL_URL" \
-            --data-binary "@$1" > curl_output.json; then
-            cat curl_output.json
-            echo "Failed to upload asset"
-            exit 1
+            --data-binary "@$1" \
+            --write-out "\n%{http_code}" \
+            -o curl_output.txt; then
+            http_code=$(tail -n 1 curl_output.txt)
+            if [ "$http_code" -eq 422 ] ; then
+                echo "Not attempting to replace asset with the same name that was already uploaded."
+            else
+                cat curl_output.txt
+                echo "Failed to upload asset"
+                exit 1
+            fi
         fi
     fi
 }

--- a/github-release/github-release.sh
+++ b/github-release/github-release.sh
@@ -48,25 +48,22 @@ add_file_to_release() {
     echo "Posting binary contents of $1 to $CURL_URL"
 
     if [ "$DRY_RUN" = "false" ] ; then
-        if ! curl -X POST \
+        http_code=$(curl -X POST \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Content-Type: application/octet-stream" \
-            --fail \
             --silent \
             "$CURL_URL" \
             --data-binary "@$1" \
-            --write-out "\n%{http_code}" \
-            -o curl_output.txt; then
-            http_code=$(tail -n 1 curl_output.txt)
-            if [ "$http_code" -eq 422 ] ; then
-                echo "Not attempting to replace asset with the same name that was already uploaded."
-            else
-                cat curl_output.txt
-                echo "Failed to upload asset"
-                exit 1
-            fi
+            --write-out "%{http_code}" \
+            -o curl_output.txt)
+        if [ "$http_code" -eq 422 ] ; then
+            echo "Not attempting to replace asset with the same name that was already uploaded."
+        else
+            cat curl_output.txt
+            echo "Failed to upload asset"
+            exit 1
         fi
     fi
 }


### PR DESCRIPTION
See https://github.com/Smaug123/test-repo/pull/7 at commit e6ab39c421946c6986805eb99dc7ceb730085efb (https://github.com/Smaug123/test-repo/actions/runs/12715546621/job/35447974832) for how this behaves when the asset doesn't exist yet (it makes a release, in this case https://github.com/Smaug123/test-repo/releases/tag/test-tag-3), and the rerun https://github.com/Smaug123/test-repo/actions/runs/12715546621/job/35448030611 for how this behaves when the asset already exists (it skips the release and gracefully ignores the failure to upload the asset).