### PR TITLE
Bump check-required* runtime from node20 to node24

### DIFF
--- a/check-required-lite/action.yaml
+++ b/check-required-lite/action.yaml
@@ -6,5 +6,5 @@ inputs:
     description: 'JSON string of the needs context, which you should give as toJSON(needs)'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/check-required/action.yml
+++ b/check-required/action.yml
@@ -10,5 +10,5 @@ outputs:
     description: 'The result of the check'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary

Bumps the `runs.using` field on `check-required` and `check-required-lite` from `node20` to `node24` so the JS runtime continues to work after GitHub's forced cutover.

## Why now

GitHub announced ([2025-09-19](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) that `node20` actions will be forced to `node24` starting **2026-06-02**. Any action whose `action.yml` declares `runs.using: node20` is affected.

## Files

- `check-required/action.yml`
- `check-required-lite/action.yaml`

## Notes

- `dist/index.js` is unchanged: typical JS code compiled for node20 runs fine on node24.
- `github-release` and `publish-nuget` are `using: composite` and unaffected.
