### PR TITLE
Add zizmor workflow for GitHub Actions static analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+name: zizmor
+
+# Static analysis of GitHub Actions workflows with zizmor
+# (https://docs.zizmor.sh). Results are uploaded as SARIF to
+# Code Scanning; findings do not fail the build.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write # SARIF upload to Code Scanning
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          min-severity: low
+          min-confidence: low


### PR DESCRIPTION
## What

Adds a workflow that runs [zizmor](https://docs.zizmor.sh) — a static analyzer for GitHub Actions workflows and composite actions — via the upstream [`zizmorcore/zizmor-action`](https://github.com/zizmorcore/zizmor-action) (SHA-pinned, v0.5.6), uploading results as SARIF to Code Scanning.

## Why

zizmor catches common CI security issues (excessive permissions, credential persistence, template injection, unpinned/impostor actions, cache poisoning). This repo publishes reusable composite actions consumed by other repositories, so static analysis of the action definitions themselves is especially valuable — and zizmor audits `action.yml` files, not just workflows.

A current offline run against `main` (zizmor 1.25.2, `--min-severity low --min-confidence low`) reports **no findings** in the existing composite actions — this workflow keeps it that way as the actions evolve.

## Design choices

- **Non-blocking**: the action does not fail the build on findings; they surface in the Security tab and as PR annotations. (Requires Code Scanning to be enabled in the repo settings — it is on by default for public repos.)
- **No paths filter**: the auditable `action.yml`/`action.yaml` files live at the repo root (not under `.github/`), and the repo is small — running on every push to `main` and every PR is cheap and avoids silently skipping a newly added action.
- **Least privilege**: top-level `permissions: {}`; the job grants only `actions: read`, `contents: read`, `security-events: write`.
- **SHA-pinned** actions with version comments. Note this repo has no Dependabot config yet, so pins won't auto-update — happy to add one in a follow-up if wanted.
- This is the repo's first workflow; the workflow itself audits clean, even under zizmor's `pedantic` persona.

This mirrors G-Research/consuldotnet#640.